### PR TITLE
Complete the code for handling the dataset scheduled daily updates.

### DIFF
--- a/src/commonMain/kotlin/com/pajato/tmdb/lib/DatasetManager.kt
+++ b/src/commonMain/kotlin/com/pajato/tmdb/lib/DatasetManager.kt
@@ -16,27 +16,25 @@ object DatasetManager {
     internal fun resetCache() = cache.clear()
 
     /** Return a dataset for a given list name. Note that this is safe to do from the UI/Main thread. */
-    suspend fun getDataset(listName: String, config: FetchConfig = FetchConfigImpl()): List<TmdbData> =
-        if (cache.isEmpty()) scheduleDailyFetches(listName, config) else cache[listName] ?: listOf(TmdbError("..."))
+    suspend fun getDataset(listName: String, config: FetchConfig = FetchConfigImpl()): List<TmdbData> {
+        if (cache.isEmpty()) scheduleDailyFetches(config)
+        return cache[listName] ?: listOf(TmdbError("..."))
+    }
 
-    /** Provide a never-ending coroutine that will refresh the export data set cache. */
-    private suspend fun scheduleDailyFetches(listName: String, config: FetchConfig): List<TmdbData> {
+    /** Provide a possibly never-ending coroutine that will refresh the export data set cache. */
+    private suspend fun scheduleDailyFetches(config: FetchConfig) {
         // Update the cache starting with the configured date and executing subsequent updates at the configured
         // interval.
-        val result = mutableListOf<TmdbData>()
-
-        while (processDailyUpdate(listName, config, now().unixMillisLong, result)) {}
-        return result
+        //val foo = processDailyUpdate(config, now().unixMillisLong)
+        processDailyUpdate(config, now().unixMillisLong)
     }
 
     /** Recursively update the dataset cache until the configured number of cycles is reached (possibly infinite). */
     private tailrec suspend fun processDailyUpdate(
-        listName: String,
         config: FetchConfig,
-        startTime: Long,
-        result: MutableList<TmdbData>
-    ): Boolean {
-        suspend fun loadCache(listName: String, config: FetchConfig): List<TmdbData> {
+        startTime: Long
+    ) {
+        suspend fun loadCache(config: FetchConfig) {
             suspend fun updateCache(data: Deferred<Map<String, List<TmdbData>>>) {
                 data.await()
                 for (entry in data.getCompleted().entries) {
@@ -47,15 +45,13 @@ object DatasetManager {
 
             val data = coroutineScope { async { dailyCacheRefreshTask(config) } }
             updateCache(data)
-            return data.await()[listName] ?: listOf(TmdbError("Empty list or invalid list name: $listName!"))
         }
 
-        /** Return the objects for the given list as soon as it has been fetched and load/update the dataset cache. */
-        return if (!config.updateAction()) false else {
+        // Handle the scheduling recursion based on the update action defined in the fetch configuration.
+        if (config.updateAction()) {
             val nextTime = startTime + config.updateInterval
-            result.clear()
-            result.addAll(loadCache(listName, config))
-            processDailyUpdate(listName, config, nextTime, result)
+            loadCache(config)
+            processDailyUpdate(config, nextTime)
         }
     }
 }

--- a/src/commonMain/kotlin/com/pajato/tmdb/lib/TmdbFetch.kt
+++ b/src/commonMain/kotlin/com/pajato/tmdb/lib/TmdbFetch.kt
@@ -32,14 +32,14 @@ interface FetchConfig {
         if (listName.isBlank() || baseUrl.isBlank()) "" else "$baseUrl${listName}_$date.json.gz"
 }
 
-/** The production implementation for the daily fetches. */
-internal class FetchConfigImpl : FetchConfig {
+/** The production implementation of the fetch configuration for the daily fetches. */
+internal class FetchConfigImpl(private val terminationOverride: Boolean = false) : FetchConfig {
     override val baseUrl: String = "http://files.tmdb.org/p/exports/"
     override val date: String = getLastExportDate(now())
     override val readTimeout: Int = 800 // Milliseconds
     override val connectTimeout: Int = 200 // Milliseconds
     override val updateInterval: Long = 24L * 60 * 60 * 1000 // Milliseconds
-    override val updateAction: () -> Boolean = { true }
+    override val updateAction: () -> Boolean = { !terminationOverride }
 }
 
 /** The platform dependent task used to refresh the cached TMDB data set for a given URL. */

--- a/src/commonTest/kotlin/com/pajato/tmdb/lib/LibraryTest.kt
+++ b/src/commonTest/kotlin/com/pajato/tmdb/lib/LibraryTest.kt
@@ -8,13 +8,14 @@ import com.soywiz.klock.hours
 import com.soywiz.klock.seconds
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.test.fail
 
 class LibraryTest {
     private fun testTmdbData(name: String) {
         val nonHomogenousCollection = "The $name collection contains inconsistent typed data!"
-        val list = listOf(createDefaultFromType(name)) //fetchLines(name)
+        val list = listOf(createDefaultFromType(name))
         assertTrue(list.size == 1 && list[0] !is TmdbError, "Detected an error in the $name default creation.")
         assertTrue(list.isNotEmpty(), "Incorrect number of $name!")
         when (name) {
@@ -122,4 +123,12 @@ class LibraryTest {
         assertTrue(result is TmdbError, "Parsing error detection failed!")
     }
 
+    @Test fun `verify that the production fetch configuration action works correctly`() {
+        val uutWithDefault = FetchConfigImpl()
+        assertTrue(uutWithDefault.updateAction(), "Wrong result!")
+        val uutWithoutOverride = FetchConfigImpl(false)
+        assertTrue(uutWithoutOverride.updateAction(), "Wrong result!")
+        val uutWithOverride = FetchConfigImpl(true)
+        assertFalse(uutWithOverride.updateAction(), "Wrong result!")
+    }
 }

--- a/src/jvmTest/kotlin/com/pajato/tmdb/lib/LibraryTestJVM.kt
+++ b/src/jvmTest/kotlin/com/pajato/tmdb/lib/LibraryTestJVM.kt
@@ -131,5 +131,17 @@ class LibraryTestJVM {
         }
     }
 
+    @Test
+    fun `test that the production fetch config can terminate`() {
+        DatasetManager.resetCache()
+        runBlocking {
+            val config = FetchConfigImpl(true)
+            val result = DatasetManager.getDataset(Collection.listName, config)
+            assertEquals(1, result.size, "Wrong size!")
+            assertTrue(result[0] is TmdbError)
+        }
+
+    }
+
 }
 


### PR DESCRIPTION
This commit wraps up the work on the daily dataset updates. The code has been simplified and code coverage established at 100%.

modified:   src/commonMain/kotlin/com/pajato/tmdb/lib/DatasetManager.kt

- getDataset(): restructure to schedule daily updates (and wait for the first one to complete) before accessing the requested dataset.

- scheduleDailyFetches(): rewrite to implement using tail recursion rather than a loop; do not return a dataset list.

- loadCache(): do not return a dataset list; iterate using recursion.

modified:   src/commonMain/kotlin/com/pajato/tmdb/lib/TmdbFetch.kt

- FetchConfigImpl: provide a flag to override the infinite nature of scheduled daily updates, this done to achieve a 100% code coverage level.

modified:   src/commonTest/kotlin/com/pajato/tmdb/lib/LibraryTest.kt

- Summary: add a test for covering all of FetchConfigImpl.

modified:   src/jvmTest/kotlin/com/pajato/tmdb/lib/LibraryTestJVM.kt

- Summary: add a test for covering scheduled daily fetch termination to achieve 100% code coverage overall.