### PR TITLE
Refactoring for clarity and simplicity.

### DIFF
--- a/src/commonMain/kotlin/com/pajato/tmdb/lib/TmdbData.kt
+++ b/src/commonMain/kotlin/com/pajato/tmdb/lib/TmdbData.kt
@@ -12,8 +12,7 @@ interface TmdbDataFactory {
 }
 
 /** The set of collections used in TMDB. */
-@Serializable
-data class Collection(val id: Int = 0, val name: String = "") : TmdbData() {
+@Serializable data class Collection(val id: Int = 0, val name: String = "") : TmdbData() {
     companion object : TmdbDataFactory {
         override val listName = "collection_ids"
         override fun create(json: String): TmdbData = createFromJson(json, Collection())
@@ -21,8 +20,7 @@ data class Collection(val id: Int = 0, val name: String = "") : TmdbData() {
 }
 
 /** The set of keywords used in TMDB. */
-@Serializable
-data class Keyword(val id: Int = 0, val name: String = "") : TmdbData() {
+@Serializable data class Keyword(val id: Int = 0, val name: String = "") : TmdbData() {
     companion object : TmdbDataFactory {
         override val listName = "keyword_ids"
         override fun create(json: String): TmdbData = createFromJson(json, Keyword())
@@ -30,8 +28,7 @@ data class Keyword(val id: Int = 0, val name: String = "") : TmdbData() {
 }
 
 /** The set of movies known to TMDB. */
-@Serializable
-data class Movie(
+@Serializable data class Movie(
     val adult: Boolean = false,
     val id: Int = -1,
     val original_title: String = "",
@@ -45,8 +42,7 @@ data class Movie(
 }
 
 /** The set of TV networks known to TMDB. */
-@Serializable
-data class Network(val id: Int = -1, val name: String = ""): TmdbData() {
+@Serializable data class Network(val id: Int = -1, val name: String = ""): TmdbData() {
     companion object : TmdbDataFactory {
         override val listName = "tv_network_ids"
         override fun create(json: String): TmdbData = createFromJson(json, Network())
@@ -54,8 +50,7 @@ data class Network(val id: Int = -1, val name: String = ""): TmdbData() {
 }
 
 /** The set of people (cast, crew, etc.) known to TMDB. */
-@Serializable
-data class Person(
+@Serializable data class Person(
     val adult: Boolean = false,
     val id: Int = -1,
     val name: String = "",
@@ -68,8 +63,7 @@ data class Person(
 }
 
 /** The set of production companies known to TMDB. */
-@Serializable
-data class ProductionCompany(val id: Int = 0, val name: String = "") : TmdbData() {
+@Serializable data class ProductionCompany(val id: Int = 0, val name: String = "") : TmdbData() {
     companion object : TmdbDataFactory {
         override val listName = "production_company_ids"
         override fun create(json: String): TmdbData = createFromJson(json, ProductionCompany())
@@ -77,8 +71,7 @@ data class ProductionCompany(val id: Int = 0, val name: String = "") : TmdbData(
 }
 
 /** The set of TV shows known to TMDB. */
-@Serializable
-data class TvSeries(val id: Int = -1, val original_name: String = "", val popularity: Double = 0.0) : TmdbData() {
+@Serializable data class TvSeries(val id: Int = -1, val original_name: String = "", val popularity: Double = 0.0) : TmdbData() {
     companion object : TmdbDataFactory {
         override val listName = "tv_series_ids"
         override fun create(json: String): TmdbData = createFromJson(json, TvSeries())

--- a/src/commonTest/kotlin/com/pajato/tmdb/lib/LibraryTest.kt
+++ b/src/commonTest/kotlin/com/pajato/tmdb/lib/LibraryTest.kt
@@ -112,10 +112,10 @@ class LibraryTest {
         assertEquals(errorItem, createFromJson("{}", errorItem), "Invalid error item creation!")
     }
 
-    @Test fun `when the data access config object is defaulted verify correct results`() {
-        val config = FetchConfigImpl()
-        assertEquals("http://files.tmdb.org/p/exports/", config.baseUrl, "Config base URL error!")
-        assertEquals(10, config.date.length, "Config date error!")
+    @Test fun `when the data access context object is defaulted verify correct results`() {
+        val context = ContextImpl()
+        assertEquals("http://files.tmdb.org/p/exports/", context.baseUrl, "Base URL error in context!")
+        assertEquals(10, context.date.length, "Date error in context!")
     }
 
     @Test fun `when an invalid list name is parsed verify an error result`() {
@@ -123,12 +123,12 @@ class LibraryTest {
         assertTrue(result is TmdbError, "Parsing error detection failed!")
     }
 
-    @Test fun `verify that the production fetch configuration action works correctly`() {
-        val uutWithDefault = FetchConfigImpl()
+    @Test fun `verify that the production fetch context action works correctly`() {
+        val uutWithDefault = ContextImpl()
         assertTrue(uutWithDefault.updateAction(), "Wrong result!")
-        val uutWithoutOverride = FetchConfigImpl(false)
+        val uutWithoutOverride = ContextImpl(false)
         assertTrue(uutWithoutOverride.updateAction(), "Wrong result!")
-        val uutWithOverride = FetchConfigImpl(true)
+        val uutWithOverride = ContextImpl(true)
         assertFalse(uutWithOverride.updateAction(), "Wrong result!")
     }
 }


### PR DESCRIPTION
This commit provides massive refactoring for names to better reflect reality. Also some minor code refactoring has also been applied for simplicity.

File Chnanges:

modified:   src/commonMain/kotlin/com/pajato/tmdb/lib/DatasetManager.kt
modified:   src/commonTest/kotlin/com/pajato/tmdb/lib/LibraryTest.kt
modified:   src/jvmMain/kotlin/com/pajato/tmdb/lib/TmdbFetchJVM.kt
modified:   src/jvmTest/kotlin/com/pajato/tmdb/lib/LibraryTestJVM.kt

- Summary: rename config -> context and FetchConfig -> FetchContext

modified:   src/commonMain/kotlin/com/pajato/tmdb/lib/TmdbData.kt

- Summary: minor tweaks to tighten up code.

modified:   src/commonMain/kotlin/com/pajato/tmdb/lib/TmdbFetch.kt

- Summary: use an abstract class instead of an interface; use better names; use context rather than config.