### PR TITLE
Implement a true scheduler to handle updates.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,11 @@
 plugins {
     kotlin("multiplatform") version "1.3.21"
     id("kotlinx-serialization") version "1.3.21"
+    `maven-publish`
 }
+
+group = "com.pajato.tmdb-lib"
+version = "0.0.1"
 
 repositories {
     maven("https://dl.bintray.com/kotlin/kotlin-eap")

--- a/src/commonMain/kotlin/com/pajato/tmdb/lib/DatasetManager.kt
+++ b/src/commonMain/kotlin/com/pajato/tmdb/lib/DatasetManager.kt
@@ -6,49 +6,27 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 
-/** Manage a global collection of TMDB data sets that are updated daily. */
+/** Manage a global cache of TMDB data sets that are updated daily. */
 @ExperimentalCoroutinesApi
 object DatasetManager {
-    /** Provide a cache for downloaded export data. */
-    private val cache = mutableMapOf<String, List<TmdbData>>()
-
-    /** Provide a test only operation to clear the cache. */
-    internal fun resetCache() = cache.clear()
+    internal val datasetCache = mutableMapOf<String, List<TmdbData>>()
 
     /** Return a dataset for a given list name. Note that this is safe to do from the UI/Main thread. */
     suspend fun getDataset(listName: String, context: FetchContext = ContextImpl()): List<TmdbData> {
-        if (cache.isEmpty()) scheduleDailyFetches(context)
-        return cache[listName] ?: listOf(TmdbError("..."))
+        if (datasetCache.isEmpty()) processCacheUpdate(context, now().unixMillisLong)
+        return datasetCache[listName] ?: listOf(TmdbError("..."))
     }
 
-    /** Provide a possibly never-ending coroutine that will refresh the export data set cache. */
-    private suspend fun scheduleDailyFetches(context: FetchContext) {
-        // Update the cache starting with the configured date and executing subsequent updates at the configured
-        // interval.
-        //val foo = processDailyUpdate(context, now().unixMillisLong)
-        processDailyUpdate(context, now().unixMillisLong)
-    }
-
-    /** Recursively update the dataset cache until the configured number of cycles is reached (possibly infinite). */
-    private tailrec suspend fun processDailyUpdate(context: FetchContext, startTime: Long) {
-        suspend fun loadCache() {
-            suspend fun updateCache(data: Deferred<Map<String, List<TmdbData>>>) {
-                data.await()
-                for (entry in data.getCompleted().entries) {
-                    if (entry.key == ANONYMOUS) continue
-                    cache[entry.key] = entry.value
-                }
+    internal suspend fun processCacheUpdate(context: FetchContext, startTime: Long) {
+        suspend fun updateCache(data: Deferred<Map<String, List<TmdbData>>>) {
+            data.await()
+            for (entry in data.getCompleted().entries) {
+                if (entry.key == ANONYMOUS) continue
+                datasetCache[entry.key] = entry.value
             }
-
-            val data = coroutineScope { async { dailyCacheRefreshTask(context) } }
-            updateCache(data)
         }
 
-        // Handle the scheduling recursion based on the update action defined in the fetch configuration.
-        if (context.updateAction()) {
-            val nextTime = startTime + context.updateIntervalMillis
-            loadCache()
-            processDailyUpdate(context, nextTime)
-        }
+        coroutineScope { updateCache(async { dailyCacheRefreshTask(context) }) }
+        scheduleNextUpdate(context, startTime + context.updateIntervalMillis)
     }
 }

--- a/src/commonMain/kotlin/com/pajato/tmdb/lib/TmdbFetch.kt
+++ b/src/commonMain/kotlin/com/pajato/tmdb/lib/TmdbFetch.kt
@@ -12,8 +12,8 @@ import kotlin.reflect.KClass
 internal const val tmdbBlankErrorMessage = "Blank JSON argument encountered."
 internal const val ANONYMOUS = "anonymous" // provided for testing/code coverage only.
 
-/** Return a platform dependent cache entry for a given dataset. */
-internal expect suspend fun getEntry(listName: String, context: FetchContext): Pair<String, MutableList<TmdbData>>
+internal expect suspend fun getCacheEntry(listName: String, context: FetchContext): Pair<String, MutableList<TmdbData>>
+internal expect fun scheduleNextUpdate(context: FetchContext, nextTime: Long) // date: Long, task: () -> Unit): Long
 
 /** The TMDB dataset fetch context to differentiate production vs testing access. */
 abstract class FetchContext {
@@ -57,7 +57,7 @@ internal suspend fun fetchLines(subclass: KClass<out TmdbData>, context: FetchCo
         Pair<String, MutableList<TmdbData>> {
     val listName = subclass.getListName()
     val url = listName.getUrl(context)
-    return if (listName.isBlank() || url.isBlank()) getErrorEntry() else getEntry(listName, context)
+    return if (listName.isBlank() || url.isBlank()) getErrorEntry() else getCacheEntry(listName, context)
 }
 
 /** Provide an error entry for testing and network errors. */

--- a/src/jvmMain/kotlin/com/pajato/tmdb/lib/TmdbFetchJVM.kt
+++ b/src/jvmMain/kotlin/com/pajato/tmdb/lib/TmdbFetchJVM.kt
@@ -1,13 +1,18 @@
 package com.pajato.tmdb.lib
 
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import java.net.ConnectException
 import java.net.URL
+import java.util.Date
+import java.util.Timer
 import java.util.zip.GZIPInputStream
+import kotlin.concurrent.schedule
 
-/** Return a list using the given name handling any exceptions. */
-internal actual suspend fun getEntry(listName: String, context: FetchContext): Pair<String, MutableList<TmdbData>> =
+internal actual suspend fun getCacheEntry(listName: String, context: FetchContext):
+        Pair<String, MutableList<TmdbData>> =
     withContext(Dispatchers.IO) {
         fun fetchData(): Pair<String, MutableList<TmdbData>> =
             URL(listName.getUrl(context)).openConnection().apply {
@@ -25,3 +30,10 @@ internal actual suspend fun getEntry(listName: String, context: FetchContext): P
             listName to mutableListOf<TmdbData>(TmdbError("Could not connect. See terminal output."))
         }
     }
+
+@ExperimentalCoroutinesApi
+internal actual fun scheduleNextUpdate(context: FetchContext, nextTime: Long) {
+    if (context.updateAction()) {
+        Timer().schedule(Date(nextTime)) { runBlocking { DatasetManager.processCacheUpdate(context, nextTime) } }
+    }
+}


### PR DESCRIPTION
This commit implements a true scheduler for the JVM platform which allows the Android implementation to work, albeit with a performance issue that needs resolving.

File changes:

modified:   build.gradle.kts

- Summary: allow publishing to local maven repo.

modified:   src/commonMain/kotlin/com/pajato/tmdb/lib/DatasetManager.kt

- Summary: minor doc updates and name changes; overhaul scheduling operations.

modified:   src/commonMain/kotlin/com/pajato/tmdb/lib/TmdbFetch.kt

- Summary: add platform dependent scheduling; enhance names (getEntry() -> getCacheEntry())

modified:   src/jvmMain/kotlin/com/pajato/tmdb/lib/TmdbFetchJVM.kt

- Summary: implement JVM scheduling.

modified:   src/jvmTest/kotlin/com/pajato/tmdb/lib/LibraryTestJVM.kt

- Summary: update tests to deal with true scheduling.